### PR TITLE
Linux Pointer Scripting

### DIFF
--- a/mouse.py
+++ b/mouse.py
@@ -5,14 +5,20 @@ http://stackoverflow.com/questions/281133/controlling-the-mouse-from-python-in-o
 
 #!/usr/bin/python
 
-import objc
+import sys
 
 def setMousePosition(x, y):
-    bndl = objc.loadBundle('CoreGraphics', globals(),
+    if sys.platform == "linux2":
+        import subprocess
+        subprocess.call(['xdotool', 'mousemove', str(x), str(y)])
+    elif sys.platform == "darwin": 
+        import objc
+        bndl = objc.loadBundle('CoreGraphics', globals(),
             '/System/Library/Frameworks/ApplicationServices.framework')
-    objc.loadBundleFunctions(bndl, globals(),
+        objc.loadBundleFunctions(bndl, globals(),
             [('CGWarpMouseCursorPosition', 'v{CGPoint=dd}')])
-    CGWarpMouseCursorPosition((x, y))
+        CGWarpMouseCursorPosition((x, y)) 
+
 
 if __name__ == "__main__":
     setMousePosition(200, 200)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 Kludgy Eye Tracker
 
 
-mouse support only works on mac currently
-Requires numpy, opencv
+Cursor control only works on mac and linux currently.
+
+Requires numpy, opencv.
+
+Linux requires xdotool for mouse movement.


### PR DESCRIPTION
Added pointer control in Linux with xdotools. Using python's sys.platform to determine if OS is Linux 2.6 or OSX; if OS is unrecognized, does nothing. 
The flag for Windows is just "win32" (even for 64-bit... for some reason), but I'm not familiar with pointer scripting in that environment so I left 
the case out.
